### PR TITLE
docs(readme): Clarify setup instructions and pnpm workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,26 @@
 
 ## Overview
 
-**Render.js** is a library that rendering HTML elements for TypeScript and JavaScript.
+**Render.js** is a TypeScript / JavaScript library for rendering HTML elements.
 
 ## Usage
 
+### 1. Install or Import
+
+Install as a package (TypeScript):
+```bash
+npm i yone1130/render-js
+```
+
+or direct importing from CDN (JavaScript):
+```js
+import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/render.js";
+```
+
+### 2. Use
+
 Example code (with App Creator):
 ```js
-import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render@1.0.0/render.js";
-
 class Greeting extends RenderComponent {
     constructor() {
         super();
@@ -61,8 +73,6 @@ render.runApp({
 
 or just rendering (with Builder):
 ```js
-import { Render } from "https://cdn.yoneyo.com/scripts/render@1.0.0/render.js";
-
 const render = new Render();
 const root = document.getElementById("root");
 
@@ -108,7 +118,7 @@ render.build({
 ### 1. Install Packages
 
 ```bash
-npm install
+pnpm i
 ```
 
 ### 2. Build
@@ -116,7 +126,7 @@ npm install
 Compile to JavaScript.
 
 ```bash
-npm run build
+pnpm run build
 ```
 
 Emitted JavaScript files will be output to the `dist/` directory.

--- a/README_JP.md
+++ b/README_JP.md
@@ -4,13 +4,27 @@
 
 [Read in English >](./README.md)
 
-## Overview
+## 概要
 
-**Render.js** は、TypeScript と JavaScript で利用できるHTMLレンダリングライブラリです。
+**Render.js** は、TypeScript / JavaScript 用のHTMLレンダリングライブラリです。
 
 ## 利用方法
 
-コード例 (App Creator):
+### 1. インストールまたはインポート
+
+パッケージとしてインストール (TypeScript):
+```bash
+npm i yone1130/render-js
+```
+
+またはCDNから直接インポート (JavaScript):
+```js
+import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/render.js";
+```
+
+### 2. 使う
+
+サンプルコード (App Creator):
 ```js
 import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render@1.0.0/render.js";
 
@@ -108,7 +122,7 @@ render.build({
 ### 1. パッケージをインストールする
 
 ```bash
-npm install
+pnpm i
 ```
 
 ### 2. ビルド
@@ -116,7 +130,7 @@ npm install
 JavaScript にコンパイルします。
 
 ```bash
-npm run build
+pnpm run build
 ```
 
 コンパイルされたJavaScriptファイルが `dist/` ディレクトリに出力されます。


### PR DESCRIPTION
## Summary

Update the English and Japanese README files to make Render.js setup instructions clearer, document both package installation and CDN import usage, and align contributor commands with the pnpm-based development workflow.

## Changes

### Documentation

- #9
  - **Clarify usage setup**: Add an explicit install/import step that explains package installation for TypeScript usage and direct CDN imports for JavaScript usage.
  - **Improve README wording**: Refine the project overview and usage section labels in both `README.md` and `README_JP.md` for clearer, more natural documentation.
  - **Update CDN import example**: Replace the primary documented CDN URL with the `render-js@1.0.0-beta.2` path.
  - **Use pnpm for setup**: Replace `npm install` with `pnpm i` in the local development instructions.
  - **Use pnpm for builds**: Replace `npm run build` with `pnpm run build` so the documented build command matches the project workflow.

## Scope

This PR is limited to documentation updates in `README.md` and `README_JP.md`. It does not change runtime code, build configuration, package metadata, or generated output.
