### PR TITLE
chore(pnpm): Add `@yoneyo/version` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
         "start-docs": "http-server ./docs -p 3000",
         "start-test": "http-server ./ -p 3001"
     },
-    "dependencies": {},
+    "dependencies": {
+        "@yoneyo/version": "github:yone1130/version-js"
+    },
     "devDependencies": {
-        "typescript": "^6.0.3",
-        "http-server": "^14.1.1"
+        "http-server": "^14.1.1",
+        "typescript": "^6.0.3"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@yoneyo/version':
+        specifier: github:yone1130/version-js
+        version: https://codeload.github.com/yone1130/version-js/tar.gz/a63542245622adda6cddec662199e0c5e494815d
     devDependencies:
       http-server:
         specifier: ^14.1.1
@@ -16,6 +20,10 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@yoneyo/version@https://codeload.github.com/yone1130/version-js/tar.gz/a63542245622adda6cddec662199e0c5e494815d':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/yone1130/version-js/tar.gz/a63542245622adda6cddec662199e0c5e494815d}
+    version: 1.3.0
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -217,6 +225,8 @@ packages:
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
 snapshots:
+
+  '@yoneyo/version@https://codeload.github.com/yone1130/version-js/tar.gz/a63542245622adda6cddec662199e0c5e494815d': {}
 
   ansi-styles@4.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

Add `@yoneyo/version` as a runtime dependency so the project can consume the shared version package from `yone1130/version-js`, with pnpm lockfile updates to keep installs reproducible.

## Changes

### Chore

- #11
  - **Add shared version package**: Adds `@yoneyo/version` to `package.json` using the GitHub dependency specifier `github:yone1130/version-js`.
  - **Keep existing dev tooling intact**: Preserves the current `http-server` and `typescript` development dependencies while normalizing their order.
  - **Pin GitHub dependency resolution**: Updates `pnpm-lock.yaml` with the resolved GitHub tarball for `@yoneyo/version`.
  - **Record resolved package version**: Locks `@yoneyo/version` to version `1.3.0` from commit `a63542245622adda6cddec662199e0c5e494815d`.

## Scope

This PR is limited to dependency metadata updates in `package.json` and `pnpm-lock.yaml`. It does not change application source code, build scripts, documentation, or runtime behavior beyond making the shared version package available as an installable dependency.
