### PR TITLE
chore: Update Render.js CDN imports to distribution bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i yone1130/render-js
 
 or direct importing from CDN (JavaScript):
 ```js
-import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/render.js";
+import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 ```
 
 ### 2. Use

--- a/README_JP.md
+++ b/README_JP.md
@@ -19,15 +19,13 @@ npm i yone1130/render-js
 
 またはCDNから直接インポート (JavaScript):
 ```js
-import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/render.js";
+import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 ```
 
 ### 2. 使う
 
 サンプルコード (App Creator):
 ```js
-import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render@1.0.0/render.js";
-
 class Greeting extends RenderComponent {
     constructor() {
         super();
@@ -75,8 +73,6 @@ render.runApp({
 
 またはレンダリングのみ (Builder):
 ```js
-import { Render } from "https://cdn.yoneyo.com/scripts/render@1.0.0/render.js";
-
 const render = new Render();
 const root = document.getElementById("root");
 

--- a/docs/scripts/main.js
+++ b/docs/scripts/main.js
@@ -9,7 +9,7 @@
  * 
  */
 
-import { Render } from 'https://cdn.yoneyo.com/scripts/render@1.0.0/render.js';
+import { Render } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 
 const render = new Render();
 const root = document.getElementById("root");

--- a/docs/scripts/pages/examples.js
+++ b/docs/scripts/pages/examples.js
@@ -9,7 +9,7 @@
  * 
  */
 
-import { Render } from 'https://cdn.yoneyo.com/scripts/render@1.0.0/render.js';
+import { Render } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 
 const render = new Render();
 

--- a/examples/app/scripts/app.js
+++ b/examples/app/scripts/app.js
@@ -9,7 +9,7 @@
  * 
  */
 
-import { Render, RenderApp, RenderComponent } from 'https://cdn.yoneyo.com/scripts/render@1.0.0/render.js';
+import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 
 class Greeting extends RenderComponent {
     constructor() {

--- a/examples/counter/scripts/counter.js
+++ b/examples/counter/scripts/counter.js
@@ -9,7 +9,7 @@
  * 
  */
 
-import { Render, RenderApp, RenderComponent } from 'https://cdn.yoneyo.com/scripts/render@1.0.0/render.js';
+import { Render, RenderApp, RenderComponent } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 
 class CounterPage extends RenderComponent {
     constructor() {

--- a/examples/hello-world/scripts/hello-world.js
+++ b/examples/hello-world/scripts/hello-world.js
@@ -9,7 +9,7 @@
  * 
  */
 
-import { Render } from 'https://cdn.yoneyo.com/scripts/render@1.0.0/render.js';
+import { Render } from "https://cdn.yoneyo.com/scripts/render-js@1.0.0-beta.2/dist/render.js";
 
 function app({ title, message }) {
     const { $div, $h1, $p } = render;


### PR DESCRIPTION
## Summary

This PR updates the Render JS CDN import references across documentation, docs site scripts, and example applications so they consistently load the current beta distribution bundle from `render-js@1.0.0-beta.2/dist/render.js`.

## Changes

### Documentation

- #15
  - **Fix README CDN import path**: Updates the English README CDN example to import from the `dist/render.js` bundle path.
  - **Fix Japanese README CDN import path**: Updates the Japanese README setup example to use the same current `render-js` beta distribution URL.
  - **Remove stale Japanese README imports**: Removes outdated inline example imports that referenced the older `render@1.0.0/render.js` package path.

### Chore

- #15
  - **Update main docs script import**: Changes `docs/scripts/main.js` to load `Render` from `render-js@1.0.0-beta.2/dist/render.js`.
  - **Update examples page import**: Changes `docs/scripts/pages/examples.js` to use the same corrected CDN bundle path.
  - **Update app example import**: Aligns the app example with the current `render-js` beta CDN distribution bundle.
  - **Update counter example import**: Aligns the counter example with the corrected CDN import path.
  - **Update hello-world example import**: Aligns the hello-world example with the corrected CDN import path.

## Scope

This PR is limited to CDN import path cleanup in documentation, docs scripts, and example files. It does not change runtime library source code, package configuration, build output, or application behavior beyond ensuring that docs and examples reference the correct published distribution bundle.
