### PR TITLE
refactor: Rename render contracts from model to interface

### DIFF
--- a/src/app/app.interface.ts
+++ b/src/app/app.interface.ts
@@ -9,11 +9,11 @@
  * 
  */
 
+import { RenderComponent } from "../component/component.js";
 import { Render } from "../render.js";
 
-export interface RenderComponentModel {
+export interface RenderAppInterface {
     id: string | null;
     render: Render;
-    rendering(): void;
-    build({ children, ref }: { children: Array<HTMLElement>, ref?: { nowrapper?: boolean } }): Array<HTMLElement>;
+    build({ children }: { children: Array<HTMLElement | RenderComponent> }): Array<HTMLElement>;
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -11,9 +11,9 @@
 
 import { RenderComponent } from "../component/component.js";
 import { Render, RenderElement } from "../render.js";
-import { RenderAppModel } from "./app.model.js";
+import { RenderAppInterface } from "./app.interface.js";
 
-export abstract class RenderApp implements RenderAppModel {
+export abstract class RenderApp implements RenderAppInterface {
     constructor({
         id,
     }: {

--- a/src/component/component.interface.ts
+++ b/src/component/component.interface.ts
@@ -9,11 +9,11 @@
  * 
  */
 
-import { RenderComponent } from "../component/component.js";
 import { Render } from "../render.js";
 
-export interface RenderAppModel {
+export interface RenderComponentInterface {
     id: string | null;
     render: Render;
-    build({ children }: { children: Array<HTMLElement | RenderComponent> }): Array<HTMLElement>;
+    rendering(): void;
+    build({ children, ref }: { children: Array<HTMLElement>, ref?: { nowrapper?: boolean } }): Array<HTMLElement>;
 }

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -10,9 +10,9 @@
  */
 
 import { Render, RenderElement } from "../render.js";
-import { RenderComponentModel } from "./component.model.js";
+import { RenderComponentInterface } from "./component.interface.js";
 
-export abstract class RenderComponent implements RenderComponentModel {
+export abstract class RenderComponent implements RenderComponentInterface {
     constructor({
         id,
     }: {


### PR DESCRIPTION
## Summary

Rename the Render app and component contract files and interface types from `Model` terminology to `Interface` terminology, making the codebase naming more accurate for TypeScript interfaces.

## Changes

### Refactors

- #17
  - **Rename app contract interface**: Rename `RenderAppModel` to `RenderAppInterface` to better describe the contract implemented by `RenderApp`.
  - **Rename component contract interface**: Rename `RenderComponentModel` to `RenderComponentInterface` to align component contract naming with its actual TypeScript role.
  - **Update app interface module**: Rename `src/app/app.model.ts` to `src/app/app.interface.ts` and update the `RenderApp` import path.
  - **Update component interface module**: Rename `src/component/component.model.ts` to `src/component/component.interface.ts` and update the `RenderComponent` import path.

## Scope

This PR is limited to naming and import path cleanup for existing render contract interfaces. It does not change runtime behavior, public method signatures, rendering logic, or component/app lifecycle behavior.
