### PR TITLE
style: Standardize app and component import order

### DIFF
--- a/src/app/app.interface.ts
+++ b/src/app/app.interface.ts
@@ -9,8 +9,8 @@
  * 
  */
 
-import { RenderComponent } from "../component/component.js";
 import { Render } from "../render.js";
+import { RenderComponent } from "../component/component.js";
 
 export interface RenderAppInterface {
     id: string | null;

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -9,9 +9,9 @@
  * 
  */
 
-import { RenderComponent } from "../component/component.js";
-import { Render, RenderElement } from "../render.js";
 import { RenderAppInterface } from "./app.interface.js";
+import { Render, RenderElement } from "../render.js";
+import { RenderComponent } from "../component/component.js";
 
 export abstract class RenderApp implements RenderAppInterface {
     constructor({

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -9,8 +9,8 @@
  * 
  */
 
-import { Render, RenderElement } from "../render.js";
 import { RenderComponentInterface } from "./component.interface.js";
+import { Render, RenderElement } from "../render.js";
 
 export abstract class RenderComponent implements RenderComponentInterface {
     constructor({


### PR DESCRIPTION
## Summary

Standardizes import declaration ordering in the app and component modules to improve consistency and reduce style-only noise in future diffs.

## Changes

### Style

- #23
  - **Normalize app interface imports**: Reorders imports in `app.interface.ts` so the shared `Render` dependency is listed before the component dependency.
  - **Align app implementation imports**: Reorders imports in `app.ts` so the local interface import is followed by shared render primitives and component dependencies.
  - **Align component implementation imports**: Reorders imports in `component.ts` so the local component interface import appears before shared render imports.

## Scope

This PR is limited to import ordering changes in `src/app/app.interface.ts`, `src/app/app.ts`, and `src/component/component.ts`. It does not change runtime behavior, public APIs, class implementations, type definitions, or build configuration.
