### PR TITLE
refactor(RenderElement): Remove innerHTML element option

### DIFF
--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -22,12 +22,6 @@ export class RenderElement {
     create(tagName: keyof HTMLElementTagNameMap): HTMLElement {
         this.element = document.createElement(tagName);
 
-        if (typeof this.options.innerHTML === "string") {
-            const html = document.createRange().createContextualFragment(this.options.innerHTML);
-            this.element.appendChild(html);
-            return this.element;
-        }
-
         if (typeof this.options.id === "string") {
             this.element.id = this.options.id;
         }

--- a/src/types/element-options.ts
+++ b/src/types/element-options.ts
@@ -20,5 +20,4 @@ export interface ElementOptions {
     onClick?: (this: HTMLElement, ev: MouseEvent) => void;
     textContent?: string;
     children?: Array<HTMLElement>;
-    innerHTML?: string;
 }


### PR DESCRIPTION
## Summary

Remove support for the `innerHTML` element option to prevent raw HTML string rendering during `RenderElement` creation and keep element content composition limited to explicit, structured DOM APIs.

## Changes

### Refactors

- #31
  - **Remove `innerHTML` from `ElementOptions`**: Deletes the `innerHTML?: string` option from the element configuration type so consumers can no longer pass raw HTML strings through the public element options API.
  - **Remove raw HTML parsing from `RenderElement.create()`**: Deletes the `createContextualFragment()` rendering path that parsed `innerHTML` and appended it directly to the created element.
  - **Preserve normal element option handling**: Ensures created elements continue to process `id`, `className`, `textContent`, anchor/image attributes, event handlers, and `children` through the standard creation flow.

## Scope

This PR only removes the `innerHTML` option and its rendering behavior from element creation. It does not change the behavior of `textContent`, child element composition, event binding, attribute assignment, custom element creation, or root rendering logic.
